### PR TITLE
fix upload image example

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ const imageMeta = {
 }
 
 const imageData = new FormData()
-imageData.append('meta', JSON.stringify(imageMeta), 'meta.json')
+imageData.append('meta', JSON.stringify(imageMeta))
 imageData.append('file', createReadStream('./hellowechatpay.png'), 'hellowechatpay.png')
 
 ;(async () => {


### PR DESCRIPTION
according to the document from wechat, remove the filename field

![image](https://user-images.githubusercontent.com/1078125/121227956-c0dd4480-c8be-11eb-86b6-86caab6c3482.png)

Refer Url: https://pay.weixin.qq.com/wiki/doc/apiv3_partner/apis/chapter9_0_1.shtml