### PR TITLE
fix: #35 transformer.js signer 对一些api不能正确获取商户号

### DIFF
--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -32,7 +32,8 @@ class Transformer {
    * @return {object} - With data signature
    */
   static signer(data) {
-    const { sign_type: type = 'MD5', mch_id: mchid } = data;
+    const { sign_type: type = 'MD5' } = data;
+    const mchid = data.mch_id || data.mchid;
     if (Transformer.mchid) {
       assert.ok(Transformer.mchid === mchid, `The data.mch_id(${mchid}) doesn't matched init one(${Transformer.mchid})`);
     }


### PR DESCRIPTION
详细信息见 #35 。
fix #35 .